### PR TITLE
Fix: char passed to isprint and isspace, must be int

### DIFF
--- a/sds.c
+++ b/sds.c
@@ -928,7 +928,7 @@ sds sdscatrepr(sds s, const char *p, size_t len) {
         case '\a': s = sdscatlen(s,"\\a",2); break;
         case '\b': s = sdscatlen(s,"\\b",2); break;
         default:
-            if (isprint(*p))
+            if (isprint((int) (*p)))
                 s = sdscatfmt(s,"%c",*p);
             else
                 s = sdscatprintf(s,"\\x%02x",(unsigned char)*p);
@@ -997,7 +997,7 @@ sds *sdssplitargs(const char *line, int *argc) {
     *argc = 0;
     while(1) {
         /* skip blanks */
-        while(*p && isspace(*p)) p++;
+        while(*p && isspace((int) (*p))) p++;
         if (*p) {
             /* get a token */
             int inq=0;  /* set to 1 if we are in "quotes" */
@@ -1033,7 +1033,7 @@ sds *sdssplitargs(const char *line, int *argc) {
                     } else if (*p == '"') {
                         /* closing quote must be followed by a space or
                          * nothing at all. */
-                        if (*(p+1) && !isspace(*(p+1))) goto err;
+                        if (*(p+1) && !isspace((int) (*(p+1)))) goto err;
                         done=1;
                     } else if (!*p) {
                         /* unterminated quotes */
@@ -1048,7 +1048,7 @@ sds *sdssplitargs(const char *line, int *argc) {
                     } else if (*p == '\'') {
                         /* closing quote must be followed by a space or
                          * nothing at all. */
-                        if (*(p+1) && !isspace(*(p+1))) goto err;
+                        if (*(p+1) && !isspace((int) (*(p+1)))) goto err;
                         done=1;
                     } else if (!*p) {
                         /* unterminated quotes */


### PR DESCRIPTION
The following use of `isprint()` and other `<ctype.h>` functions triggers an error:
https://github.com/jcorporation/sds/blob/f1d014592afcf1bab57a93830c04c396c931faf6/sds.c#L931
where `p` is a `const char *p` from function `sdscatrepr()`:
https://github.com/jcorporation/sds/blob/f1d014592afcf1bab57a93830c04c396c931faf6/sds.c#L917

This happens multiple times in the code. Need to explicitly cast to `int` like:
``` c
if (isprint((int) (*p)))
```

Otherwise an error: `array subscript has type 'char' [-Werror=char-subscripts]` occurs. 
Referring to GCC 9s `ctype.h`:

```c
/* These macros are intentionally written in a manner that will trigger
   a gcc -Wall warning if the user mistakenly passes a 'char' instead
   of an int containing an 'unsigned char'.  Note that the sizeof will
   always be 1, which is what we want for mapping EOF to __CTYPE_PTR[0];
   the use of a raw index inside the sizeof triggers the gcc warning if
   __c was of type char, and sizeof masks side effects of the extra __c.
   Meanwhile, the real index to __CTYPE_PTR+1 must be cast to int,
   since isalpha(0x100000001LL) must equal isalpha(1), rather than being
   an out-of-bounds reference on a 64-bit machine.  */
```