### PR TITLE
Fix: typos in function comments

### DIFF
--- a/sds.c
+++ b/sds.c
@@ -846,9 +846,10 @@ int sdscmp(const sds s1, const sds s2) {
  * separator, NULL is returned.
  *
  * Note that 'sep' is able to split a string using
- * a multi-character separator. For example
- * sdssplit("foo_-_bar","_-_"); will return two
- * elements "foo" and "bar".
+ * a multi-character separator. For example, with string: 
+ * sds s = sdsnew("foo_-_bar"); int count;
+ * sdssplitlen(s, sdslen(s), "_-_", 3, &count); will return two
+ * elements "foo" and "bar" with count set to 2.
  *
  * This version of the function is binary-safe but
  * requires length arguments.

--- a/sds.c
+++ b/sds.c
@@ -779,6 +779,11 @@ void sdssubstr(sds s, size_t start, size_t len) {
  *
  * The string is modified in-place.
  *
+ * NOTE: this function can be misleading and can have unexpected behaviour,
+ * specifically when you want the length of the new string to be 0.
+ * Having start==end will result in a string with one character.
+ * please consider using sdssubstr instead.
+ *
  * Example:
  *
  * s = sdsnew("Hello World");

--- a/sds.c
+++ b/sds.c
@@ -78,7 +78,7 @@ static inline char sdsReqType(size_t string_size) {
  * If NULL is used for 'init' the string is initialized with zero bytes.
  * If SDS_NOINIT is used, the buffer is left uninitialized;
  *
- * The string is always null-termined (all the sds strings are, always) so
+ * The string is always null-terminated (all the sds strings are, always) so
  * even if you create an sds string with:
  *
  * mystring = sdsnewlen("abc",3);
@@ -408,7 +408,7 @@ sds sdscatlen(sds s, const void *t, size_t len) {
     return s;
 }
 
-/* Append the specified null termianted C string to the sds string 's'.
+/* Append the specified null terminated C string to the sds string 's'.
  *
  * After the call, the passed sds string is no longer valid and all the
  * references must be substituted with the new pointer returned by the call. */
@@ -437,7 +437,7 @@ sds sdscpylen(sds s, const char *t, size_t len) {
     return s;
 }
 
-/* Like sdscpylen() but 't' must be a null-termined string so that the length
+/* Like sdscpylen() but 't' must be a null-terminated string so that the length
  * of the string is obtained with strlen(). */
 sds sdscpy(sds s, const char *t) {
     return sdscpylen(s, t, strlen(t));
@@ -456,7 +456,7 @@ int sdsll2str(char *s, long long value) {
     size_t l;
 
     /* Generate the string representation, this method produces
-     * an reversed string. */
+     * a reversed string. */
     if (value < 0) {
         /* Since v is unsigned, if value==LLONG_MIN, -LLONG_MIN will overflow. */
         if (value != LLONG_MIN) {
@@ -497,7 +497,7 @@ int sdsull2str(char *s, unsigned long long v) {
     size_t l;
 
     /* Generate the string representation, this method produces
-     * an reversed string. */
+     * a reversed string. */
     p = s;
     do {
         *p++ = '0'+(v%10);
@@ -724,7 +724,7 @@ sds sdscatfmt(sds s, char const *fmt, ...) {
 }
 
 /* Remove the part of the string from left and from right composed just of
- * contiguous characters found in 'cset', that is a null terminted C string.
+ * contiguous characters found in 'cset', that is a null terminated C string.
  *
  * After the call, the modified sds string is no longer valid and all the
  * references must be substituted with the new pointer returned by the call.


### PR DESCRIPTION
#### Fix: typos in function comments 
- Cherry-picked from redis: https://github.com/redis/redis/commit/0bfccc55e2df349104b34608365dc17db8e0a749#diff-962cc15ef1f146d2314dd8ed9ed8e0269248faa1b1a265b437f818b2c91f5d31
- Cherry-picked from redis: https://github.com/redis/redis/commit/1c71038540f8877adfd5eb2b6a6013a1a761bc6c#diff-962cc15ef1f146d2314dd8ed9ed8e0269248faa1b1a265b437f818b2c91f5d31

#### Upd: sdsrange function comment 
- `sdsrange(...)` comment update. Cherry-picked from redis: https://github.com/redis/redis/commit/ae418eca24ba53a7dca07b0e7065f856e625469b

#### Upd: sdssplitlen function comment
- `sdsplitlen(...)` comment update. `sdssplit(...)` is non-existent, use `sdsplitlen(...)` as an example