### PR TITLE
Fix: sdscatvprintf efficiency improvements

### DIFF
--- a/sds.c
+++ b/sds.c
@@ -568,7 +568,7 @@ sds sdscatvprintf(sds s, const char *fmt, va_list ap) {
     }
 
     /* Finally concat the obtained string to the SDS string and return it. */
-    t = sdscat(s, buf);
+    t = sdscatlen(s, buf, bufstrlen);
     if (buf != staticbuf) s_free(buf);
     return t;
 }


### PR DESCRIPTION
Fix for a non-complete cherry-pick made 191ec8175b574a201f9d7a73dfbcb354ccb886de

Origially cherry-picked from redis: https://github.com/redis/redis/commit/f4ca3d8757d6abb3536610ddb7b9ab3ad39e81df#diff-962cc15ef1f146d2314dd8ed9ed8e0269248faa1b1a265b437f818b2c91f5d31