### PR TITLE
README.md note on `sdscatlen`

### DIFF
--- a/README.md
+++ b/README.md
@@ -266,6 +266,8 @@ sds sdscat(sds s, const char *t);
 The main string concatenation functions are `sdscatlen` and `sdscat` that are
 identical, the only difference being that `sdscat` does not have an explicit
 length argument since it expects a null terminated string.
+Note that `sdscatlen` does not stop copying upon a null in the source
+(unlike the standard `strncat`).
 
 ```c
 sds s = sdsempty();


### PR DESCRIPTION
The documentation somewhat implies how `sdscatlen` can copy `\0`,
but i felt like it was not perfectly clear,
because prior knowledge on `strncat` muddies the water.

If my edit is deemed unacceptable for some reason,
I would like to ask for something of equal meaning to be added.