### PR TITLE
Fix null pointer dereference on failed memory reallocation

### DIFF
--- a/sds.c
+++ b/sds.c
@@ -1290,8 +1290,9 @@ sds *sdssplitargs(const char *line, int *argc) {
                 if (*p) p++;
             }
             /* add the token to the vector */
-            vector = s_realloc(vector,((*argc)+1)*sizeof(char*));
-            if (vector == NULL) goto err;
+            char **tmpvector = s_realloc(vector,((*argc)+1)*sizeof(char*));
+            if (tmpvector == NULL) goto err;
+            vector = tmpvector;
             vector[*argc] = current;
             (*argc)++;
             current = NULL;


### PR DESCRIPTION
This PR fixes a minor bug in `sdssplitargs`.

When the reallocation of `vector` fails, `free` should be called on the original pointer when cleaning up. The current implementation may lead to dereferencing a null pointer.